### PR TITLE
Updates for compatibility with newest snakemake versions (8+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Snakemake](https://img.shields.io/badge/snakemake-≥7.0.0-brightgreen.svg)](https://snakemake.github.io)
+[![Snakemake](https://img.shields.io/badge/snakemake-≥9.0.0-brightgreen.svg)](https://snakemake.github.io)
 
 # Snakemake Profile for Running on AWS ParallelCluster with the Slurm Scheduler
 

--- a/config.yaml
+++ b/config.yaml
@@ -27,4 +27,5 @@ printshellcmds: True
 scheduler: greedy
 use-conda: True
 cluster-generic-cancel-cmd: scancel
+cluster-generic-status-cmd: status-scontrol.sh
 max-status-checks-per-second: 10

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
-cluster:
+executor: cluster-generic
+cluster-generic-submit-cmd:
   mkdir -p logs/{rule}/ &&
   mkdir -p tmp/ && 
   sbatch
@@ -25,6 +26,5 @@ rerun-incomplete: True
 printshellcmds: True
 scheduler: greedy
 use-conda: True
-cluster-status: status-scontrol.sh
-cluster-cancel: scancel
+cluster-generic-cancel-cmd: scancel
 max-status-checks-per-second: 10


### PR DESCRIPTION
Now that permissions issues resolved, I've closed the external PR #1 and am making this from a branch of `sb-slurm` directly.

These small changes to the config.yaml are made based off information in the
[snakemake migration](https://snakemake.readthedocs.io/en/stable/getting_started/migration.html) and[ original source repo](https://github.com/jdblischak/smk-simple-slurm)
.

In conjunction with small updates to the way we interface with remote files (see variant calling repo), these changes allow us to move all repositories to the newest version of snakemake.

Note I took a second read through the docs and have found the correct arg for the status control. it now uses: `cluster-generic-status-cmd: status-scontrol.sh`